### PR TITLE
method and start based on route instead

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -154,8 +154,8 @@ func (ps *FiberPrometheus) RegisterAt(app *fiber.App, url string) {
 func (ps *FiberPrometheus) Middleware(ctx *fiber.Ctx) error {
 
 	start := time.Now()
-	method := string(ctx.Context().Method())
-	path := string(ctx.Context().Path())
+	method := ctx.Route().Method
+	path := ctx.Route().Path
 
 	if path == ps.defaultURL {
 		return ctx.Next()


### PR DESCRIPTION
For fiber route with path parameter, using ctx.Context().Method and Path will result in extra metrics on Prometheus.

For e.g:

```
route.Post("/api/:id") 
```

will result in different metrics label like `/api/firstID`, `/api/secondID` etc.

My idea is to replace `ctx.Context()` with `ctx.Route()` so that the result metrics is the same as route path: `/api/:id`

What do you think?