### PR TITLE
Allow to register with custom prometheus registry

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -40,6 +40,16 @@ type FiberPrometheus struct {
 	defaultURL      string
 }
 
+// Register FiberPrometheus Collectors to
+// a custom Registry
+func (fp *FiberPrometheus) MustRegister(registry *prometheus.Registry) {
+	registry.MustRegister(
+		fp.requestsTotal,
+		fp.requestDuration,
+		fp.requestInFlight,
+	)
+}
+
 func create(servicename, namespace, subsystem string, labels map[string]string) *FiberPrometheus {
 	constLabels := make(prometheus.Labels)
 	if servicename != "" {


### PR DESCRIPTION
Added `FiberPrometheus.MustRegister` to allow
for registering collectors with a custom provided
prometheus registry

Closes #106