### PR TITLE
feat: Add handlers

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -145,9 +145,14 @@ func NewWithLabels(labels map[string]string, namespace, subsystem string) *Fiber
 }
 
 // RegisterAt will register the prometheus handler at a given URL
-func (ps *FiberPrometheus) RegisterAt(app *fiber.App, url string) {
+func (ps *FiberPrometheus) RegisterAt(app *fiber.App, url string, handlers ...fiber.Handler) {
 	ps.defaultURL = url
-	app.Get(ps.defaultURL, adaptor.HTTPHandler(promhttp.Handler()))
+
+	h := []fiber.Handler{}
+	h = append(h, handlers...)
+	h = append(h, adaptor.HTTPHandler(promhttp.Handler()))
+
+	app.Get(ps.defaultURL, h...)
 }
 
 // Middleware is the actual default middleware implementation

--- a/middleware.go
+++ b/middleware.go
@@ -148,10 +148,7 @@ func NewWithLabels(labels map[string]string, namespace, subsystem string) *Fiber
 func (ps *FiberPrometheus) RegisterAt(app *fiber.App, url string, handlers ...fiber.Handler) {
 	ps.defaultURL = url
 
-	h := []fiber.Handler{}
-	h = append(h, handlers...)
-	h = append(h, adaptor.HTTPHandler(promhttp.Handler()))
-
+	h := append(handlers, adaptor.HTTPHandler(promhttp.Handler()))
 	app.Get(ps.defaultURL, h...)
 }
 


### PR DESCRIPTION
Add the options to add fiber handlers to the route register by `fiberprometheus`.
Can be useful if for example some authentication need to be added just for this route.
