### PR TITLE
refactor: use functional constructor

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -48,39 +48,50 @@ type fiberPrometheusOptions struct {
 	registry    prometheus.Registerer
 }
 
-type Opts func(*fiberPrometheusOptions)
+// Option is used to set options when creating a new instance of FiberPrometheus.
+//
+// Example usage:
+//
+//     prom := New("my_service", WithNamespace("my_namespace"))
+//
+type Option func(*fiberPrometheusOptions)
 
-func WithServiceName(serviceName string) Opts {
+// WithServiceName sets the service name as a constant label.
+func WithServiceName(serviceName string) Option {
 	return func(o *fiberPrometheusOptions) {
 		o.serviceName = serviceName
 	}
 }
 
-func WithNamespace(namespace string) Opts {
+// WithNamespace will prefix the metrics with the given namespace.
+func WithNamespace(namespace string) Option {
 	return func(o *fiberPrometheusOptions) {
 		o.namespace = namespace
 	}
 }
 
-func WithSubsystem(subsystem string) Opts {
+// WithSubsystem will prefix the metrics with the given subsystem.
+func WithSubsystem(subsystem string) Option {
 	return func(o *fiberPrometheusOptions) {
 		o.subsystem = subsystem
 	}
 }
 
-func WithLabels(labels map[string]string) Opts {
+// WithLabels will set constant labels for the metrics.
+func WithLabels(labels map[string]string) Option {
 	return func(o *fiberPrometheusOptions) {
 		o.labels = labels
 	}
 }
 
-func WithRegistry(registry prometheus.Registerer) Opts {
+// WithRegistry will register the collector with the given registry.
+func WithRegistry(registry prometheus.Registerer) Option {
 	return func(o *fiberPrometheusOptions) {
 		o.registry = registry
 	}
 }
 
-func create(opts ...Opts) *FiberPrometheus {
+func create(opts ...Option) *FiberPrometheus {
 	opt := &fiberPrometheusOptions{
 		subsystem: "http",
 		registry:  prometheus.DefaultRegisterer,
@@ -164,7 +175,7 @@ func create(opts ...Opts) *FiberPrometheus {
 
 // New creates a new instance of FiberPrometheus middleware
 // serviceName is available as a const label
-func New(serviceName string, opts ...Opts) *FiberPrometheus {
+func New(serviceName string, opts ...Option) *FiberPrometheus {
 	return create(append(opts, WithServiceName(serviceName))...)
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -175,6 +175,8 @@ func New(serviceName string, opts ...Opts) *FiberPrometheus {
 //
 // For e.g. namespace = "my_app", subsystem = "http" then metrics would be
 // `my_app_http_requests_total{...,service= "serviceName"}`
+//
+// Deprecated: Use New instead.
 func NewWith(serviceName, namespace, subsystem string) *FiberPrometheus {
 	return create(WithServiceName(serviceName), WithNamespace(namespace), WithSubsystem(subsystem))
 }
@@ -187,6 +189,8 @@ func NewWith(serviceName, namespace, subsystem string) *FiberPrometheus {
 // For e.g. namespace = "my_app", subsystem = "http" and labels = map[string]string{"key1": "value1", "key2":"value2"}
 // then then metrics would become
 // `my_app_http_requests_total{...,key1= "value1", key2= "value2" }``
+//
+// Deprecated: Use New instead.
 func NewWithLabels(labels map[string]string, namespace, subsystem string) *FiberPrometheus {
 	return create(WithNamespace(namespace), WithSubsystem(subsystem), WithLabels(labels))
 }
@@ -199,6 +203,8 @@ func NewWithLabels(labels map[string]string, namespace, subsystem string) *Fiber
 // For e.g. namespace = "my_app", subsystem = "http" and labels = map[string]string{"key1": "value1", "key2":"value2"}
 // then then metrics would become
 // `my_app_http_requests_total{...,key1= "value1", key2= "value2" }``
+//
+// Deprecated: Use New instead.
 func NewWithRegistry(registry prometheus.Registerer, serviceName, namespace, subsystem string, labels map[string]string) *FiberPrometheus {
 	return create(WithRegistry(registry), WithServiceName(serviceName), WithNamespace(namespace), WithSubsystem(subsystem), WithLabels(labels))
 }

--- a/middleware.go
+++ b/middleware.go
@@ -40,65 +40,17 @@ type FiberPrometheus struct {
 	defaultURL      string
 }
 
-type fiberPrometheusOptions struct {
-	serviceName string
-	namespace   string
-	subsystem   string
-	labels      map[string]string
-	registry    prometheus.Registerer
-}
-
-// Option is used to set options when creating a new instance of FiberPrometheus.
-//
-// Example usage:
-//
-//     prom := New("my_service", WithNamespace("my_namespace"))
-//
-type Option func(*fiberPrometheusOptions)
-
-// WithServiceName sets the service name as a constant label.
-func WithServiceName(serviceName string) Option {
-	return func(o *fiberPrometheusOptions) {
-		o.serviceName = serviceName
-	}
-}
-
-// WithNamespace will prefix the metrics with the given namespace.
-func WithNamespace(namespace string) Option {
-	return func(o *fiberPrometheusOptions) {
-		o.namespace = namespace
-	}
-}
-
-// WithSubsystem will prefix the metrics with the given subsystem.
-func WithSubsystem(subsystem string) Option {
-	return func(o *fiberPrometheusOptions) {
-		o.subsystem = subsystem
-	}
-}
-
-// WithLabels will set constant labels for the metrics.
-func WithLabels(labels map[string]string) Option {
-	return func(o *fiberPrometheusOptions) {
-		o.labels = labels
-	}
-}
-
-// WithRegistry will register the collector with the given registry.
-func WithRegistry(registry prometheus.Registerer) Option {
-	return func(o *fiberPrometheusOptions) {
-		o.registry = registry
-	}
-}
-
 func create(opts ...Option) *FiberPrometheus {
+	// set default options
 	opt := &fiberPrometheusOptions{
 		subsystem: "http",
 		registry:  prometheus.DefaultRegisterer,
 	}
+	// apply options
 	for _, o := range opts {
 		o(opt)
 	}
+
 	constLabels := make(prometheus.Labels)
 	if opt.serviceName != "" {
 		constLabels["service"] = opt.serviceName

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -221,7 +221,7 @@ func TestMiddlewareWithCustomRegistry(t *testing.T) {
 	srv := httptest.NewServer(promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 	t.Cleanup(srv.Close)
 
-	promfiber := NewWithRegistry(registry, "unique-service", "my_service_with_name", "http", nil)
+	promfiber := New("unique-service", WithRegistry(registry), WithNamespace("my_service_with_name"))
 	app.Use(promfiber.Middleware)
 
 	app.Get("/", func(c *fiber.Ctx) error {

--- a/options.go
+++ b/options.go
@@ -1,0 +1,75 @@
+//
+// Copyright (c) 2021-present Ankur Srivastava and Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package fiberprometheus
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type fiberPrometheusOptions struct {
+	serviceName string
+	namespace   string
+	subsystem   string
+	labels      map[string]string
+	registry    prometheus.Registerer
+}
+
+// Option is used to set options when creating a new instance of FiberPrometheus.
+//
+// Example usage:
+//
+//     prom := New("my_service", WithNamespace("my_namespace"))
+//
+type Option func(*fiberPrometheusOptions)
+
+// WithServiceName sets the service name as a constant label.
+func WithServiceName(serviceName string) Option {
+	return func(o *fiberPrometheusOptions) {
+		o.serviceName = serviceName
+	}
+}
+
+// WithNamespace will prefix the metrics with the given namespace.
+func WithNamespace(namespace string) Option {
+	return func(o *fiberPrometheusOptions) {
+		o.namespace = namespace
+	}
+}
+
+// WithSubsystem will prefix the metrics with the given subsystem.
+func WithSubsystem(subsystem string) Option {
+	return func(o *fiberPrometheusOptions) {
+		o.subsystem = subsystem
+	}
+}
+
+// WithLabels will set constant labels for the metrics.
+func WithLabels(labels map[string]string) Option {
+	return func(o *fiberPrometheusOptions) {
+		o.labels = labels
+	}
+}
+
+// WithRegistry will register the collector with the given registry.
+func WithRegistry(registry prometheus.Registerer) Option {
+	return func(o *fiberPrometheusOptions) {
+		o.registry = registry
+	}
+}


### PR DESCRIPTION
Hi again,

I noticed that fiberprometheus now has quite a few constructors and the more configurable the middleware will be, the more complex these constructors will get. 

What do you think about introducing a functional `options` constructor, which is much more flexible and doesn't require breaking changes or a new constructor for every additional option? 

 The PR at its current state is non breaking. I added a depreciation notice to all the constructor to encourage users to only use the `New` function. 