### PR TITLE
Allow fiber.Router implementation in RegisterAt

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -157,7 +157,7 @@ func NewWithRegistry(registry prometheus.Registerer, serviceName, namespace, sub
 }
 
 // RegisterAt will register the prometheus handler at a given URL
-func (ps *FiberPrometheus) RegisterAt(app *fiber.App, url string, handlers ...fiber.Handler) {
+func (ps *FiberPrometheus) RegisterAt(app fiber.Router, url string, handlers ...fiber.Handler) {
 	ps.defaultURL = url
 
 	h := append(handlers, adaptor.HTTPHandler(promhttp.Handler()))


### PR DESCRIPTION
This change allows mounting onto a `fiber.Router`, rather than only on the `*fiber.App` directly. Because `*fiber.App` also implements `fiber.Router`, functionality is not affected.

The change would allow adding metrics in code that does not have access to the `*fiber.App`, but e.g. a fiber.Router than has been returned from `*fiber.App.Group(..)`